### PR TITLE
refactor(frontend): centraliza a lógica de formatação da condição do produto

### DIFF
--- a/frontend/src/components/seller/ProductCard.tsx
+++ b/frontend/src/components/seller/ProductCard.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/common/Badge';
 import type { Product } from '@/types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEdit, faTrash, faQrcode, faImage, faCalendar, faFilePdf } from '@fortawesome/free-solid-svg-icons';
+import { formatProductCondition, getConditionVariant } from '@/utils/formatters';
 
 interface ProductCardProps {
   product: Product;
@@ -24,19 +25,8 @@ export function ProductCard({
   onStatusChange,
   showActions = true,
 }: ProductCardProps) {
-  const getConditionBadge = (condition?: string) => {
-    const conditionMap: Record<string, { label: string; variant: 'success' | 'warning' | 'error' }> = {
-      'NEW': { label: 'Novo', variant: 'success' },
-      'LIKE_NEW': { label: 'Como Novo', variant: 'success' },
-      'GOOD': { label: 'Bom', variant: 'success' },
-      'FAIR': { label: 'Razoável', variant: 'warning' },
-      'POOR': { label: 'Ruim', variant: 'error' },
-    };
-
-    return conditionMap[condition || 'GOOD'] || { label: 'Bom', variant: 'success' };
-  };
-
-  const conditionBadge = getConditionBadge(product.condition);
+  const conditionLabel = formatProductCondition(product.condition);
+  const conditionVariant = getConditionVariant(product.condition);
 
   return (
     <Card hoverable className="overflow-hidden h-full flex flex-col border border-gray-100 shadow-sm hover:shadow-xl transition-all duration-300 group">
@@ -67,8 +57,8 @@ export function ProductCard({
 
         {/* Condition Badge (Overlay bottom left) */}
         <div className="absolute bottom-3 left-3 z-10">
-          <Badge variant={conditionBadge.variant} className="shadow-sm font-semibold">
-            {conditionBadge.label}
+          <Badge variant={conditionVariant} className="shadow-sm font-semibold">
+            {conditionLabel}
           </Badge>
         </div>
       </div>

--- a/frontend/src/components/seller/QRCodeDisplay.tsx
+++ b/frontend/src/components/seller/QRCodeDisplay.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/common/Badge';
 import type { Product } from '@/types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPrint, faDownload, faQrcode } from '@fortawesome/free-solid-svg-icons';
+import { formatProductCondition, getConditionVariant } from '@/utils/formatters';
 
 interface QRCodeDisplayProps {
   product: Product;
@@ -83,7 +84,9 @@ export function QRCodeDisplay({ product, qrCodeUrl, onPrint, onDownload, loading
 
             <div className="flex justify-between items-start">
               <span className="text-sm text-gray-600 font-medium">Condição:</span>
-              <Badge variant="success">{product.condition || 'Bom'}</Badge>
+              <Badge variant={getConditionVariant(product.condition)}>
+                {formatProductCondition(product.condition)}
+              </Badge>
             </div>
 
             <div className="flex justify-between items-start">

--- a/frontend/src/pages/buyer/qr-scanner/BuyerDashboard.tsx
+++ b/frontend/src/pages/buyer/qr-scanner/BuyerDashboard.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import type { Product, User, PaymentMethod } from '@/types';
 import { api } from '@/services/api';
 import { useUIStore } from '@/store/uiStore';
+import { formatProductCondition, getConditionVariant } from '@/utils/formatters';
 
 export default function BuyerDashboard() {
   const [scannedProduct, setScannedProduct] = useState<Product | null>(null);
@@ -284,7 +285,9 @@ export default function BuyerDashboard() {
                 <div className="grid grid-cols-2 gap-4">
                   <div className="bg-gray-50 p-3 rounded-lg border border-gray-100 text-center">
                     <div className="text-xs text-gray-500 uppercase font-bold mb-1">Condição</div>
-                    <Badge variant="success">{scannedProduct.condition || 'Bom'}</Badge>
+                    <Badge variant={getConditionVariant(scannedProduct.condition)}>
+                      {formatProductCondition(scannedProduct.condition)}
+                    </Badge>
                   </div>
                   <div className="bg-gray-50 p-3 rounded-lg border border-gray-100 text-center">
                     <div className="text-xs text-gray-500 uppercase font-bold mb-1">Vendedor</div>

--- a/frontend/src/pages/public/ProductPublicPage.tsx
+++ b/frontend/src/pages/public/ProductPublicPage.tsx
@@ -10,6 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStore, faCheckCircle, faShoppingBag, faClock, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import type { Product } from '@/types';
 import { useUIStore } from '@/store/uiStore';
+import { formatProductCondition, getConditionVariant } from '@/utils/formatters';
 
 export default function ProductPublicPage() {
     const { id } = useParams<{ id: string }>();
@@ -178,7 +179,9 @@ export default function ProductPublicPage() {
                             <div className="space-y-4 mb-10">
                                 <div className="flex items-center justify-between py-3 border-b border-gray-100">
                                     <span className="text-gray-500 font-medium">Condição</span>
-                                    <Badge variant="success" className="font-bold">{product.condition || 'Bom'}</Badge>
+                                    <Badge variant={getConditionVariant(product.condition)} className="font-bold">
+                                        {formatProductCondition(product.condition)}
+                                    </Badge>
                                 </div>
                                 {/* @ts-ignore - Assuming seller might have a name in the response */}
                                 {product.seller && (

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -135,10 +135,39 @@ export function formatRatingStars(rating: number): string {
   const fullStars = Math.floor(rating);
   const hasHalfStar = rating % 1 >= 0.5;
   const emptyStars = 5 - Math.ceil(rating);
-  
+
   return (
     '★'.repeat(fullStars) +
     (hasHalfStar ? '½' : '') +
     '☆'.repeat(emptyStars)
   );
+}
+/**
+ * Format product condition to Portuguese
+ */
+export function formatProductCondition(condition?: string): string {
+  const conditionMap: Record<string, string> = {
+    'NEW': 'Novo',
+    'LIKE_NEW': 'Como Novo',
+    'GOOD': 'Bom',
+    'FAIR': 'Razoável',
+    'POOR': 'Ruim',
+  };
+
+  return conditionMap[condition || 'GOOD'] || 'Bom';
+}
+
+/**
+ * Get badge variant for product condition
+ */
+export function getConditionVariant(condition?: string): 'success' | 'warning' | 'error' {
+  const variantMap: Record<string, 'success' | 'warning' | 'error'> = {
+    'NEW': 'success',
+    'LIKE_NEW': 'success',
+    'GOOD': 'success',
+    'FAIR': 'warning',
+    'POOR': 'error',
+  };
+
+  return variantMap[condition || 'GOOD'] || 'success';
 }

--- a/frontend/src/utils/validators.ts
+++ b/frontend/src/utils/validators.ts
@@ -15,23 +15,23 @@ export function isValidPassword(password: string): {
   errors: string[];
 } {
   const errors: string[] = [];
-  
+
   if (password.length < 8) {
     errors.push('A senha deve ter no mínimo 8 caracteres');
   }
-  
+
   if (!/[A-Z]/.test(password)) {
     errors.push('A senha deve conter pelo menos uma letra maiúscula');
   }
-  
+
   if (!/[a-z]/.test(password)) {
     errors.push('A senha deve conter pelo menos uma letra minúscula');
   }
-  
+
   if (!/[0-9]/.test(password)) {
     errors.push('A senha deve conter pelo menos um número');
   }
-  
+
   return {
     isValid: errors.length === 0,
     errors,
@@ -212,7 +212,7 @@ export function isValidCategory(category: string): boolean {
  * Validate product condition
  */
 export function isValidProductCondition(condition: string): boolean {
-  const validConditions = ['new', 'like-new', 'good', 'fair', 'poor'];
+  const validConditions = ['NEW', 'LIKE_NEW', 'GOOD', 'FAIR', 'POOR'];
   return validConditions.includes(condition);
 }
 


### PR DESCRIPTION
refactor(frontend): centraliza a lógica de formatação da condição do produto

Extrai a lógica duplicada de formatação da condição do produto para funções utilitárias reutilizáveis. Os componentes agora utilizam formatProductCondition e getConditionVariant de utils/formatters em vez de implementações inline. Validador atualizado para usar códigos de condição em letras maiúsculas para manter a consistência.