### PR TITLE
docs(backend): adicionar documentação Swagger aos endpoints da API e DTOs

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -5,7 +5,14 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { UserRole } from '@prisma/client';
 import { CurrentUser } from '../auth/current-user.decorator';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 
+@ApiTags('analytics')
 @Controller('analytics')
 export class AnalyticsController {
   constructor(private readonly analyticsService: AnalyticsService) {}
@@ -13,6 +20,46 @@ export class AnalyticsController {
   @Get('seller')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.USER)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Obter analytics do vendedor',
+    description: 'Retorna métricas e estatísticas de vendas do usuário autenticado',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Analytics do vendedor',
+    schema: {
+      example: {
+        totalProducts: 15,
+        activeProducts: 12,
+        soldProducts: 3,
+        totalSales: 4500.00,
+        totalRevenue: 4500.00,
+        averageSalePrice: 1500.00,
+        salesByMonth: [
+          { month: '2024-01', sales: 2, revenue: 3000.00 },
+          { month: '2024-02', sales: 1, revenue: 1500.00 },
+        ],
+        salesByCategory: [
+          { category: 'Esportes', sales: 2, revenue: 3000.00 },
+          { category: 'Eletrônicos', sales: 1, revenue: 1500.00 },
+        ],
+        recentSales: [
+          {
+            id: 'purchase-id',
+            productId: 'product-id',
+            price: 1500.00,
+            status: 'COMPLETED',
+            purchaseDate: '2024-01-15T10:30:00.000Z',
+          },
+        ],
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
   getSellerAnalytics(@CurrentUser() user: any) {
     return this.analyticsService.getSellerAnalytics(user.userId);
   }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -10,23 +10,133 @@ import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { AuthGuard } from '@nestjs/passport';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiBody,
+} from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('login')
+  @ApiOperation({
+    summary: 'Login do usuário',
+    description: 'Autentica um usuário e retorna um token JWT',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Login realizado com sucesso',
+    schema: {
+      example: {
+        access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        user: {
+          id: 'user-id',
+          email: 'usuario@exemplo.com',
+          name: 'João Silva',
+          role: 'USER',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Credenciais inválidas',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+        error: 'Unauthorized',
+      },
+    },
+  })
+  @ApiBody({ type: LoginDto })
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
   }
 
   @Post('register')
+  @ApiOperation({
+    summary: 'Registro de novo usuário',
+    description: 'Cria uma nova conta de usuário no sistema',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Usuário criado com sucesso',
+    schema: {
+      example: {
+        id: 'user-id',
+        email: 'usuario@exemplo.com',
+        name: 'João Silva',
+        role: 'USER',
+        phone: '+55 11 98765-4321',
+        createdAt: '2024-01-15T10:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Dados inválidos',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ['email must be an email', 'password must be longer than or equal to 6 characters'],
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Email já cadastrado',
+    schema: {
+      example: {
+        statusCode: 409,
+        message: 'Email already exists',
+        error: 'Conflict',
+      },
+    },
+  })
+  @ApiBody({ type: RegisterDto })
   async register(@Body() registerDto: RegisterDto) {
     return this.authService.register(registerDto);
   }
 
   @UseGuards(AuthGuard('jwt'))
   @Get('me')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Obter perfil do usuário atual',
+    description: 'Retorna as informações do usuário autenticado',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Perfil do usuário',
+    schema: {
+      example: {
+        id: 'user-id',
+        email: 'usuario@exemplo.com',
+        name: 'João Silva',
+        role: 'USER',
+        phone: '+55 11 98765-4321',
+        createdAt: '2024-01-15T10:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado - token inválido ou ausente',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+        error: 'Unauthorized',
+      },
+    },
+  })
   getProfile(@Request() req) {
     return req.user;
   }

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,9 +1,19 @@
 import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
+  @ApiProperty({
+    example: 'usuario@exemplo.com',
+    description: 'Email do usuário para autenticação',
+  })
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    example: 'senha123',
+    description: 'Senha do usuário (mínimo 6 caracteres)',
+    minLength: 6,
+  })
   @IsNotEmpty()
   @MinLength(6)
   password: string;

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -7,21 +7,44 @@ import {
   IsString,
 } from 'class-validator';
 import { UserRole } from '@prisma/client';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class RegisterDto {
+  @ApiProperty({
+    example: 'usuario@exemplo.com',
+    description: 'Email do usuário para cadastro',
+  })
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    example: 'senha123',
+    description: 'Senha do usuário (mínimo 6 caracteres)',
+    minLength: 6,
+  })
   @IsNotEmpty()
   @MinLength(6)
   password: string;
 
+  @ApiProperty({
+    example: 'João Silva',
+    description: 'Nome completo do usuário',
+  })
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({
+    enum: UserRole,
+    example: UserRole.USER,
+    description: 'Função do usuário no sistema',
+  })
   @IsEnum(UserRole)
   role: UserRole;
 
+  @ApiPropertyOptional({
+    example: '+55 11 98765-4321',
+    description: 'Telefone de contato do usuário (opcional)',
+  })
   @IsOptional()
   @IsString()
   phone?: string;

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,8 +1,24 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('health')
 @Controller('health')
 export class HealthController {
   @Get()
+  @ApiOperation({
+    summary: 'Verificar saúde da aplicação',
+    description: 'Retorna o status de saúde da aplicação',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Aplicação saudável',
+    schema: {
+      example: {
+        status: 'ok',
+        message: 'Application is healthy',
+      },
+    },
+  })
   check() {
     return { status: 'ok', message: 'Application is healthy' };
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -59,7 +59,7 @@ async function bootstrap() {
 
   const config = new DocumentBuilder()
     .setTitle('Coisas de Garagem API')
-    .setDescription('The Coisas de Garagem API description')
+    .setDescription('API completa para marketplace de Garage Sales Coisas De Garagem. Permite usuários venderem e comprarem itens através de QR codes, com sistema de autenticação JWT, gestão de produtos, compras, analytics e etc.')
     .setVersion('1.0')
     .addBearerAuth()
     .build();

--- a/backend/src/products/dto/create-product.dto.ts
+++ b/backend/src/products/dto/create-product.dto.ts
@@ -8,30 +8,57 @@ import {
 } from 'class-validator';
 import { ProductCondition } from '@prisma/client';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateProductDto {
+  @ApiProperty({
+    example: 'Bicicleta Mountain Bike',
+    description: 'Nome do produto',
+  })
   @IsNotEmpty()
   @IsString()
   name: string;
 
+  @ApiProperty({
+    example: 'Bicicleta em ótimo estado, usada poucas vezes. Ideal para trilhas e passeios.',
+    description: 'Descrição detalhada do produto',
+  })
   @IsNotEmpty()
   @IsString()
   description: string;
 
+  @ApiProperty({
+    example: 1500.00,
+    description: 'Preço do produto em reais',
+    minimum: 0,
+  })
   @IsNotEmpty()
   @Type(() => Number)
   @IsNumber({ maxDecimalPlaces: 2 })
   @Min(0)
   price: number;
 
+  @ApiPropertyOptional({
+    example: 'https://example.com/images/bike.jpg',
+    description: 'URL da imagem do produto',
+  })
   @IsOptional()
   @IsString()
   imageUrl?: string;
 
+  @ApiPropertyOptional({
+    example: 'Esportes',
+    description: 'Categoria do produto',
+  })
   @IsOptional()
   @IsString()
   category?: string;
 
+  @ApiPropertyOptional({
+    enum: ProductCondition,
+    example: ProductCondition.GOOD,
+    description: 'Condição do produto (NEW, LIKE_NEW, GOOD, FAIR, POOR)',
+  })
   @IsOptional()
   @IsEnum(ProductCondition)
   condition?: ProductCondition;

--- a/backend/src/products/dto/update-product.dto.ts
+++ b/backend/src/products/dto/update-product.dto.ts
@@ -1,4 +1,44 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateProductDto } from './create-product.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ProductCondition } from '@prisma/client';
 
-export class UpdateProductDto extends PartialType(CreateProductDto) {}
+export class UpdateProductDto extends PartialType(CreateProductDto) {
+  @ApiPropertyOptional({
+    description: 'Nome do produto (opcional para atualização parcial)',
+    example: 'Bicicleta Mountain Bike Atualizada',
+  })
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Descrição detalhada do produto (opcional para atualização parcial)',
+    example: 'Bicicleta em excelente estado, com novos acessórios.',
+  })
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Preço do produto em reais (opcional para atualização parcial)',
+    example: 1800.00,
+    minimum: 0,
+  })
+  price?: number;
+
+  @ApiPropertyOptional({
+    description: 'URL da imagem do produto (opcional para atualização parcial)',
+    example: 'https://example.com/images/bike-updated.jpg',
+  })
+  imageUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'Categoria do produto (opcional para atualização parcial)',
+    example: 'Esportes',
+  })
+  category?: string;
+
+  @ApiPropertyOptional({
+    enum: ProductCondition,
+    example: ProductCondition.LIKE_NEW,
+    description: 'Condição do produto (opcional para atualização parcial)',
+  })
+  condition?: ProductCondition;
+}

--- a/backend/src/products/products.controller.ts
+++ b/backend/src/products/products.controller.ts
@@ -17,7 +17,17 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { UserRole } from '@prisma/client';
 import { CurrentUser } from '../auth/current-user.decorator';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+} from '@nestjs/swagger';
 
+@ApiTags('products')
 @Controller('products')
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
@@ -25,11 +35,77 @@ export class ProductsController {
   @Post()
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.USER)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Criar novo produto',
+    description: 'Cria um novo produto no sistema. O usuário autenticado será o vendedor.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Produto criado com sucesso',
+    schema: {
+      example: {
+        id: 'product-id',
+        sellerId: 'user-id',
+        name: 'Bicicleta Mountain Bike',
+        description: 'Bicicleta em ótimo estado',
+        price: 1500.00,
+        currency: 'BRL',
+        imageUrl: 'https://example.com/image.jpg',
+        category: 'Esportes',
+        condition: 'GOOD',
+        qrCode: 'unique-qr-code',
+        isAvailable: true,
+        isReserved: false,
+        isSold: false,
+        createdAt: '2024-01-15T10:30:00.000Z',
+        updatedAt: '2024-01-15T10:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Dados inválidos',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiBody({ type: CreateProductDto })
   create(@Body() createProductDto: CreateProductDto, @CurrentUser() user: any) {
-    return this.productsService.create(createProductDto, user.userId); // userId comes from JwtStrategy validate
+    return this.productsService.create(createProductDto, user.userId);
   }
 
   @Get()
+  @ApiOperation({
+    summary: 'Listar todos os produtos',
+    description: 'Retorna uma lista de todos os produtos disponíveis no sistema',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de produtos',
+    schema: {
+      example: [
+        {
+          id: 'product-id',
+          sellerId: 'user-id',
+          name: 'Bicicleta Mountain Bike',
+          description: 'Bicicleta em ótimo estado',
+          price: 1500.00,
+          currency: 'BRL',
+          imageUrl: 'https://example.com/image.jpg',
+          category: 'Esportes',
+          condition: 'GOOD',
+          qrCode: 'unique-qr-code',
+          isAvailable: true,
+          isReserved: false,
+          isSold: false,
+          createdAt: '2024-01-15T10:30:00.000Z',
+          updatedAt: '2024-01-15T10:30:00.000Z',
+        },
+      ],
+    },
+  })
   findAll() {
     return this.productsService.findAll();
   }
@@ -37,11 +113,41 @@ export class ProductsController {
   @Get('my-products')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.USER)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Listar meus produtos',
+    description: 'Retorna todos os produtos cadastrados pelo usuário autenticado',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de produtos do usuário',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
   getMyProducts(@CurrentUser() user: any) {
     return this.productsService.getSellerProducts(user.userId);
   }
 
   @Get(':id')
+  @ApiOperation({
+    summary: 'Buscar produto por ID',
+    description: 'Retorna os detalhes de um produto específico',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID do produto',
+    example: 'product-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Detalhes do produto',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
   findOne(@Param('id') id: string) {
     return this.productsService.findOne(id);
   }
@@ -49,6 +155,37 @@ export class ProductsController {
   @Patch(':id')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.USER)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Atualizar produto',
+    description: 'Atualiza os dados de um produto existente. Apenas o vendedor pode atualizar.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID do produto',
+    example: 'product-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Produto atualizado com sucesso',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Dados inválidos',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Sem permissão para atualizar este produto',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
+  @ApiBody({ type: UpdateProductDto })
   update(
     @Param('id') id: string,
     @Body() updateProductDto: UpdateProductDto,
@@ -60,11 +197,54 @@ export class ProductsController {
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.USER)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Deletar produto',
+    description: 'Remove um produto do sistema. Apenas o vendedor pode deletar.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID do produto',
+    example: 'product-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Produto deletado com sucesso',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Sem permissão para deletar este produto',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
   remove(@Param('id') id: string, @CurrentUser() user: any) {
     return this.productsService.remove(id, user.userId);
   }
 
   @Patch(':id/reserve')
+  @ApiOperation({
+    summary: 'Reservar produto',
+    description: 'Marca um produto como reservado',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID do produto',
+    example: 'product-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Produto reservado com sucesso',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
   reserve(@Param('id') id: string) {
     return this.productsService.reserve(id);
   }
@@ -72,6 +252,32 @@ export class ProductsController {
   @Patch(':id/unreserve')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.USER)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Cancelar reserva do produto',
+    description: 'Remove a reserva de um produto. Apenas o vendedor pode cancelar.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID do produto',
+    example: 'product-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Reserva cancelada com sucesso',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Sem permissão para cancelar reserva',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
   unreserve(@Param('id') id: string, @CurrentUser() user: any) {
     return this.productsService.unreserve(id, user.userId);
   }
@@ -79,6 +285,32 @@ export class ProductsController {
   @Patch(':id/sold')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.USER)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Marcar produto como vendido',
+    description: 'Marca um produto como vendido. Apenas o vendedor pode marcar.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID do produto',
+    example: 'product-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Produto marcado como vendido com sucesso',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Sem permissão para marcar como vendido',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
   markAsSold(@Param('id') id: string, @CurrentUser() user: any) {
     return this.productsService.markAsSold(id, user.userId);
   }

--- a/backend/src/purchases/dto/create-purchase.dto.ts
+++ b/backend/src/purchases/dto/create-purchase.dto.ts
@@ -1,15 +1,29 @@
 import { IsString, IsNotEmpty, IsEnum, IsOptional } from 'class-validator';
 import { PaymentMethod } from '@prisma/client';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreatePurchaseDto {
+  @ApiProperty({
+    example: 'product-id',
+    description: 'ID do produto a ser comprado',
+  })
   @IsNotEmpty()
   @IsString()
   productId: string;
 
+  @ApiPropertyOptional({
+    enum: PaymentMethod,
+    example: PaymentMethod.PIX,
+    description: 'Método de pagamento (CASH, CARD, PIX, OTHER)',
+  })
   @IsOptional()
   @IsEnum(PaymentMethod)
   paymentMethod?: PaymentMethod;
 
+  @ApiPropertyOptional({
+    example: 'Posso retirar no fim de semana',
+    description: 'Notas adicionais sobre a compra',
+  })
   @IsOptional()
   @IsString()
   notes?: string;

--- a/backend/src/purchases/purchases.controller.ts
+++ b/backend/src/purchases/purchases.controller.ts
@@ -14,13 +14,81 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { UserRole } from '@prisma/client';
 import { CurrentUser } from '../auth/current-user.decorator';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+} from '@nestjs/swagger';
 
+@ApiTags('purchases')
 @Controller('purchases')
 @UseGuards(AuthGuard('jwt'), RolesGuard)
+@ApiBearerAuth()
 export class PurchasesController {
   constructor(private readonly purchasesService: PurchasesService) {}
 
   @Get()
+  @ApiOperation({
+    summary: 'Listar compras do comprador',
+    description: 'Retorna uma lista paginada de compras feitas pelo usuário autenticado',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Número da página (padrão: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Itens por página (padrão: 20)',
+    example: 20,
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    type: String,
+    description: 'Filtrar por status (PENDING, COMPLETED, CANCELLED, REFUNDED)',
+    example: 'PENDING',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de compras',
+    schema: {
+      example: {
+        data: [
+          {
+            id: 'purchase-id',
+            productId: 'product-id',
+            buyerId: 'buyer-id',
+            sellerId: 'seller-id',
+            price: 1500.00,
+            currency: 'BRL',
+            status: 'PENDING',
+            paymentMethod: 'PIX',
+            purchaseDate: '2024-01-15T10:30:00.000Z',
+            notes: 'Posso retirar no fim de semana',
+            qrCodeScanned: false,
+            createdAt: '2024-01-15T10:30:00.000Z',
+            updatedAt: '2024-01-15T10:30:00.000Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 20,
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
   findAll(
     @CurrentUser() user: any,
     @Query('page') page?: string,
@@ -30,7 +98,6 @@ export class PurchasesController {
     const pageNumber = page ? parseInt(page, 10) : 1;
     const limitNumber = limit ? parseInt(limit, 10) : 20;
 
-    // Default to returning purchases (as a buyer)
     return this.purchasesService.findAllByBuyer(
       user.userId,
       pageNumber,
@@ -41,6 +108,44 @@ export class PurchasesController {
 
   @Post()
   @Roles(UserRole.USER)
+  @ApiOperation({
+    summary: 'Criar nova compra',
+    description: 'Cria uma nova compra de um produto. O usuário autenticado será o comprador.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Compra criada com sucesso',
+    schema: {
+      example: {
+        id: 'purchase-id',
+        productId: 'product-id',
+        buyerId: 'buyer-id',
+        sellerId: 'seller-id',
+        price: 1500.00,
+        currency: 'BRL',
+        status: 'PENDING',
+        paymentMethod: 'PIX',
+        purchaseDate: '2024-01-15T10:30:00.000Z',
+        notes: 'Posso retirar no fim de semana',
+        qrCodeScanned: false,
+        createdAt: '2024-01-15T10:30:00.000Z',
+        updatedAt: '2024-01-15T10:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Dados inválidos',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
+  @ApiBody({ type: CreatePurchaseDto })
   create(
     @Body() createPurchaseDto: CreatePurchaseDto,
     @CurrentUser() user: any,
@@ -50,17 +155,66 @@ export class PurchasesController {
 
   @Get('history')
   @Roles(UserRole.USER)
+  @ApiOperation({
+    summary: 'Histórico de compras',
+    description: 'Retorna todo o histórico de compras do usuário autenticado',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Histórico de compras',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
   getHistory(@CurrentUser() user: any) {
     return this.purchasesService.findAllByBuyer(user.userId);
   }
 
   @Get('sales')
   @Roles(UserRole.USER)
+  @ApiOperation({
+    summary: 'Histórico de vendas',
+    description: 'Retorna todo o histórico de vendas do usuário autenticado',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Histórico de vendas',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
   getSales(@CurrentUser() user: any) {
     return this.purchasesService.findAllBySeller(user.userId);
   }
 
   @Get(':id')
+  @ApiOperation({
+    summary: 'Buscar compra por ID',
+    description: 'Retorna os detalhes de uma compra específica',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID da compra',
+    example: 'purchase-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Detalhes da compra',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Sem permissão para ver esta compra',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Compra não encontrada',
+  })
   findOne(@Param('id') id: string, @CurrentUser() user: any) {
     return this.purchasesService.findOne(id, user.userId);
   }

--- a/backend/src/qr-codes/qr-codes.controller.ts
+++ b/backend/src/qr-codes/qr-codes.controller.ts
@@ -10,13 +10,51 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { AuthGuard } from '@nestjs/passport';
 import { RolesGuard } from '../auth/roles.guard';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 
+@ApiTags('qr-codes')
 @Controller('qr-codes')
 export class QrCodesController {
   constructor(private prisma: PrismaService) {}
 
   @Get(':productId')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Gerar QR Code do produto',
+    description: 'Gera um QR Code que redireciona para a página do produto no frontend',
+  })
+  @ApiParam({
+    name: 'productId',
+    description: 'ID do produto',
+    example: 'product-id',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'QR Code gerado com sucesso',
+    schema: {
+      example: {
+        url: 'https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=http%3A%2F%2Flocalhost%3A5173%2Fproduct%2Fproduct-id',
+        code: 'unique-qr-code',
+        productUrl: 'http://localhost:5173/product/product-id',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Produto não encontrado',
+  })
   async getQRCode(@Param('productId') productId: string) {
     const product = await this.prisma.product.findUnique({
       where: { id: productId },
@@ -37,6 +75,65 @@ export class QrCodesController {
 
   @Post('scan')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Escanear QR Code',
+    description: 'Valida um QR Code e retorna os dados do produto e do vendedor',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        qrCode: {
+          type: 'string',
+          description: 'Código QR ou ID do produto',
+          example: 'unique-qr-code',
+        },
+      },
+      required: ['qrCode'],
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'QR Code válido',
+    schema: {
+      example: {
+        product: {
+          id: 'product-id',
+          sellerId: 'seller-id',
+          name: 'Bicicleta Mountain Bike',
+          description: 'Bicicleta em ótimo estado',
+          price: 1500.00,
+          currency: 'BRL',
+          imageUrl: 'https://example.com/image.jpg',
+          category: 'Esportes',
+          condition: 'GOOD',
+          qrCode: 'unique-qr-code',
+          isAvailable: true,
+          isReserved: false,
+          isSold: false,
+          createdAt: '2024-01-15T10:30:00.000Z',
+          updatedAt: '2024-01-15T10:30:00.000Z',
+        },
+        seller: {
+          id: 'seller-id',
+          email: 'vendedor@exemplo.com',
+          name: 'João Silva',
+          role: 'USER',
+          phone: '+55 11 98765-4321',
+          createdAt: '2024-01-15T10:30:00.000Z',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Não autorizado',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'QR Code inválido',
+  })
   async scanQRCode(@Body() data: { qrCode: string }) {
     // Try to find by qrCode field first
     let product = await this.prisma.product.findUnique({


### PR DESCRIPTION
docs(backend): adicionar documentação Swagger aos endpoints da API e DTOs

* Adicionar documentação abrangente OpenAPI/Swagger em todos os controllers e DTOs.
* Incluir decoradores @ApiTags, @ApiOperation, @ApiResponse e @ApiProperty.
* Documentar endpoints para os módulos de auth, products, purchases, analytics, health e qr-codes.
* Atualizar a descrição da API na configuração principal do Swagger para fornecer uma visão detalhada das funcionalidades da API do marketplace Coisas de Garagem.