### PR TITLE
feat: integra VLibras Widget para acessibilidade em Libras

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,19 @@
 
 <body>
   <div id="root"></div>
+
+  <!-- VLibras Widget -->
+  <div vw class="enabled">
+    <div vw-access-button class="active"></div>
+    <div vw-plugin-wrapper>
+      <div class="vw-plugin-top-wrapper"></div>
+    </div>
+  </div>
+  <script src="https://vlibras.gov.br/app/vlibras-plugin.js"></script>
+  <script>
+    new window.VLibras.Widget('https://vlibras.gov.br/app');
+  </script>
+
   <script type="module" src="/src/main.tsx"></script>
 </body>
 


### PR DESCRIPTION
Adiciona o VLibras Widget (tradutor para Libras do Governo Federal) no frontend. A marcação fica dentro do <body> e fora do <div id="root">, evitando que o React sobrescreva o widget ao trocar de rota.