### PR TITLE
fix(docker): garante migrations na inicialização do container e refina interações do frontend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=builder /app/prisma ./prisma
 USER node
 
 EXPOSE 3000
-CMD [ "npm", "run", "start:prod" ]
+CMD ["sh", "-c", "npx prisma migrate deploy && npm run start:prod"]

--- a/frontend/src/components/auth/LoginModal.tsx
+++ b/frontend/src/components/auth/LoginModal.tsx
@@ -57,7 +57,6 @@ export function LoginModal({ isOpen, onClose, onSuccess }: LoginModalProps) {
             theme: 'outline',
             size: 'large',
             text: 'signin_with',
-            width: '100%',
           });
         }
       }, 100);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -36,7 +36,7 @@ export function Sidebar({ mode }: SidebarProps) {
 
   return (
     <aside
-      className="hidden md:flex flex-col fixed inset-y-0 left-0 z-30 bg-surface border-r border-border w-20"
+      className="hidden md:flex flex-col fixed inset-y-0 left-0 z-50 bg-surface border-r border-border w-20"
       aria-label={`Menu do ${mode === 'seller' ? 'vendedor' : 'comprador'}`}
     >
       {/* Logo */}
@@ -95,7 +95,10 @@ export function Sidebar({ mode }: SidebarProps) {
         <Tooltip content="Sair da conta" side="right">
           <button
             type="button"
-            onClick={() => setShowLogoutModal(true)}
+            onClick={(e) => {
+              setShowLogoutModal(true);
+              e.currentTarget.blur();
+            }}
             aria-label="Sair da conta"
             className="flex items-center justify-center w-10 h-10 rounded-lg text-text-subtle hover:text-error hover:bg-error/10 transition-colors"
           >

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -46,7 +46,6 @@ export default function LoginPage() {
           theme: 'outline',
           size: 'large',
           text: 'signin_with',
-          width: '100%',
         });
       }
     }

--- a/frontend/src/pages/buyer/purchases/PurchasesPage.tsx
+++ b/frontend/src/pages/buyer/purchases/PurchasesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBagShopping, faMagnifyingGlass, faBoxOpen, faMoneyBillWave } from '@fortawesome/free-solid-svg-icons';
@@ -32,7 +32,7 @@ export default function PurchasesPage() {
   const [category, setCategory] = useState<string>('all');
   const pageSize = 9;
 
-  const notify = makeNotifier(addNotification);
+  const notify = useMemo(() => makeNotifier(addNotification), [addNotification]);
 
   const filteredPurchases = purchases.filter((purchase) => {
     const matchesSearch =
@@ -58,11 +58,10 @@ export default function PurchasesPage() {
   const startIndex = (currentPage - 1) * pageSize;
   const paginatedPurchases = sortedPurchases.slice(startIndex, startIndex + pageSize);
 
-  // Reseta a paginação quando filtros/ordenação mudam.
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+  // Reset page when it goes out of bounds
+  if (totalPages > 0 && currentPage > totalPages) {
     setCurrentPage(1);
-  }, [searchTerm, sortBy, sortOrder, category]);
+  }
 
   useEffect(() => {
     let isMounted = true;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -153,9 +153,8 @@ export const api = {
     if (ENABLE_MOCK_DATA) {
       return mockApi.logout();
     }
-    return fetchApi<{ message: string }>('/auth/logout', {
-      method: 'POST',
-    });
+    // No backend endpoint exists for logout, handle it client-side
+    return { success: true, data: { message: 'Logged out successfully' } };
   },
 
   register: async (data: RegisterRequest): Promise<ApiResult<LoginResponse>> => {


### PR DESCRIPTION
fix(docker): garante migrations na inicialização do container e refina interações do frontend

### Backend
- Atualiza comando de entrada do Dockerfile para executar `npx prisma migrate deploy` antes do `start:prod`

### Frontend
- Remove `width: '100%'` da configuração do botão do Google no LoginModal e na LoginPage
- Corrige sobreposição da Sidebar alterando o z-index de `z-30` para `z-50`
- Adiciona `blur()` no botão de logout para eliminar o foco residual após o clique
- Padroniza o notifier da PurchasesPage com `useMemo`, evitando recriação a cada render
- Corrige reset de paginação fora do intervalo diretamente durante o render, sem `useEffect`
- Remove chamada ao endpoint de logout inexistente, tratando a saída no cliente